### PR TITLE
Fix/gm levelup

### DIFF
--- a/contracts/game/GameManager.sol
+++ b/contracts/game/GameManager.sol
@@ -302,12 +302,10 @@ contract GameManager is Initializable, AccessControlUpgradeable {
             ) >= levelCost.ingredients,
             "Insufficient ingredients"
         );
-        ERC1155Burnable(ingredientNft).safeTransferFrom(
+        ERC1155Burnable(ingredientNft).burn(
             sender,
-            address(this),
             levelUpIngredientId,
-            levelCost.ingredients,
-            ""
+            levelCost.ingredients
         );
 
         // Level up

--- a/contracts/token/WaifuToken.sol
+++ b/contracts/token/WaifuToken.sol
@@ -215,13 +215,8 @@ contract WaifuToken is ERC20Custom, AccessControl {
         return (amountLessTax_);
     }
 
-    function withdrawETH(
-        uint256 amount_
-    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        (bool success, ) = _msgSender().call{value: amount_}("");
-        if (!success) {
-            _revert(TransferFailed.selector);
-        }
+    fallback() external {
+        revert("Not supported");
     }
 
     function withdrawERC20(


### PR DESCRIPTION
1. Burn ingredients when level up waifu instead of transferring to GM
2. Updated GM to prevent accidental ETH deposits